### PR TITLE
Add Home dashboard view

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,7 +6,9 @@
     [boards]="boards()"
     [activeBoard]="activeBoard()"
     [opened]="isSidebarOpen"
+    [homeActive]="viewHome"
     (selected)="selectBoard($event)"
+    (homeSelect)="showHome()"
     (enableDarkMode)="toggleDarkMode($event)"
     (closeSidebar)="closeSidebar()"
     (add)="addBoard()"
@@ -18,26 +20,32 @@
     class="main flex-1 duration-700"
     [ngClass]="{ 'sm:ml-[26rem] lg:ml-[30rem]': isSidebarOpen }"
   >
-    <app-navbar
-      [opened]="isSidebarOpen"
-      [activeBoard]="activeBoard()"
-      [boards]="boards()"
-      [darkMode]="darkMode"
-      (boardSelect)="selectBoard($event)"
-      (boardAdd)="addBoard()"
-      (boardEdit)="editBoard()"
-      (boardDelete)="deleteBoard()"
-      (taskAdd)="addTask()"
-    ></app-navbar>
+    <ng-container *ngIf="!viewHome; else dashboard">
+      <app-navbar
+        [opened]="isSidebarOpen"
+        [activeBoard]="activeBoard()"
+        [boards]="boards()"
+        [darkMode]="darkMode"
+        (boardSelect)="selectBoard($event)"
+        (boardAdd)="addBoard()"
+        (boardEdit)="editBoard()"
+        (boardDelete)="deleteBoard()"
+        (taskAdd)="addTask()"
+      ></app-navbar>
 
-    <app-project-board
-      [darkMode]="darkMode"
-      [activeBoard]="activeBoard()"
-      (columnAdd)="editBoard()"
-      (boardEdit)="updateBoardAfterTaskReorder($event)"
-      (taskUpdate)="updateTask($event)"
-      (taskDeleteModal)="deleteTask($event)"
-      (taskUpdateModal)="editTask($event)"
-    ></app-project-board>
+      <app-project-board
+        [darkMode]="darkMode"
+        [activeBoard]="activeBoard()"
+        (columnAdd)="editBoard()"
+        (boardEdit)="updateBoardAfterTaskReorder($event)"
+        (taskUpdate)="updateTask($event)"
+        (taskDeleteModal)="deleteTask($event)"
+        (taskUpdateModal)="editTask($event)"
+      ></app-project-board>
+    </ng-container>
+
+    <ng-template #dashboard>
+      <app-home [boards]="boards()"></app-home>
+    </ng-template>
   </main>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,6 +7,7 @@ import { DeleteModalComponent } from './components/modals/delete-modal/delete-mo
 import { TaskModalComponent } from './components/modals/task-modal/task-modal.component';
 import { NavbarComponent } from './components/navbar/navbar.component';
 import { ProjectBoardComponent } from './components/project-board/project-board.component';
+import { HomeComponent } from './components/home/home.component';
 import { SidebarToggleComponent } from './components/sidebar-toggle/sidebar-toggle.component';
 import { SidebarComponent } from './components/sidebar/sidebar.component';
 import { ThemeTogglerComponent } from './components/sidebar/theme-toggler/theme-toggler.component';
@@ -24,6 +25,7 @@ import { BoardDataService } from './services/board-data/board-data.service';
     ThemeTogglerComponent,
     NavbarComponent,
     ProjectBoardComponent,
+    HomeComponent,
     SidebarToggleComponent,
     BoardModalComponent,
     DeleteModalComponent,
@@ -36,6 +38,8 @@ export class AppComponent implements OnInit {
   darkMode = false;
 
   isSidebarOpen = true;
+
+  viewHome = false;
 
   boards = this.boardDataService.boards;
 
@@ -53,11 +57,16 @@ export class AppComponent implements OnInit {
   }
 
   selectBoard(boardIdx: number) {
+    this.viewHome = false;
     this.boardDataService.selectBoard(boardIdx);
   }
 
   toggleDarkMode(enableDarkMode: boolean) {
     this.darkMode = enableDarkMode;
+  }
+
+  showHome(): void {
+    this.viewHome = true;
   }
 
   openSideBar(): void {

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -1,0 +1,11 @@
+<div class="space-y-6 p-6">
+  <h2 class="text-xl font-bold">Home</h2>
+  <p class="text-md">Total boards: {{ boardCount }}</p>
+  <div *ngFor="let stat of boardStats()" class="rounded-lg border p-4">
+    <h3 class="mb-2 font-semibold">{{ stat.name }}</h3>
+    <p>Total tasks: {{ stat.totalTasks }}</p>
+    <ul class="ml-4 list-disc">
+      <li *ngFor="let col of stat.columns">{{ col.name }}: {{ col.count }}</li>
+    </ul>
+  </div>
+</div>

--- a/src/app/components/home/home.component.scss
+++ b/src/app/components/home/home.component.scss
@@ -1,0 +1,1 @@
+/* Add minimal styling if necessary */

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -1,0 +1,29 @@
+import { CommonModule, NgFor, NgIf } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { Board } from '../../models/board.model';
+
+@Component({
+  selector: 'app-home',
+  standalone: true,
+  imports: [CommonModule, NgIf, NgFor],
+  templateUrl: './home.component.html',
+  styleUrls: ['./home.component.scss'],
+})
+export class HomeComponent {
+  @Input() boards: Board[] = [];
+
+  get boardCount(): number {
+    return this.boards.length;
+  }
+
+  boardStats() {
+    return this.boards.map((board) => ({
+      name: board.name,
+      totalTasks: board.columns.reduce((t, c) => t + c.tasks.length, 0),
+      columns: board.columns.map((c) => ({
+        name: c.name,
+        count: c.tasks.length,
+      })),
+    }));
+  }
+}

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -21,6 +21,22 @@
     class="mb-auto flex flex-col sm:w-96 lg:w-[27.6rem]"
     [ngClass]="{ hidden: !opened }"
   >
+    <button
+      (click)="selectHome()"
+      [ngClass]="
+        homeActive
+          ? 'flex h-4.8 items-center rounded-r-full bg-purple text-white sm:pl-2.4 lg:pl-3.2'
+          : 'marker flex h-4.8 items-center rounded-r-full text-grey-medium hover:bg-purple-low hover:text-purple dark:hover:bg-white sm:pl-2.4 lg:pl-3.2'
+      "
+    >
+      <img
+        src="assets/images/icon-board.svg"
+        alt="home"
+        class="mr-1.2 h-1.6 w-1.6 lg:mr-1.6"
+      />
+      <span class="text-md font-bold leading-md">Home</span>
+    </button>
+
     <h2
       class="mb-8 text-sm font-bold uppercase leading-sm tracking-sm text-grey-medium sm:pl-2.4 lg:pl-3.2"
     >

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -14,10 +14,12 @@ export class SidebarComponent {
   @Input() boards!: Board[];
   @Input() activeBoard!: Board | null;
   @Input() opened!: boolean;
+  @Input() homeActive = false;
   @Output() closeSidebar = new EventEmitter<void>();
   @Output() enableDarkMode = new EventEmitter<boolean>();
   @Output() add = new EventEmitter<void>();
   @Output() selected = new EventEmitter<number>();
+  @Output() homeSelect = new EventEmitter<void>();
 
   collapseSidebar(): void {
     this.closeSidebar.emit();
@@ -29,5 +31,9 @@ export class SidebarComponent {
 
   selectBoard(boardIdx: number): void {
     this.selected.emit(boardIdx);
+  }
+
+  selectHome(): void {
+    this.homeSelect.emit();
   }
 }


### PR DESCRIPTION
## Summary
- add dashboard HomeComponent to show metrics about boards
- display board/home views conditionally in AppComponent
- update Sidebar to include Home option

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6841c4d7442083299c50a4df0fd49e37