### PR TITLE
Add calendar view

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -23,14 +23,17 @@
       [activeBoard]="activeBoard()"
       [boards]="boards()"
       [darkMode]="darkMode"
+      [viewMode]="viewMode"
       (boardSelect)="selectBoard($event)"
       (boardAdd)="addBoard()"
       (boardEdit)="editBoard()"
       (boardDelete)="deleteBoard()"
       (taskAdd)="addTask()"
+      (viewChange)="toggleView()"
     ></app-navbar>
 
     <app-project-board
+      *ngIf="viewMode === 'kanban'"
       [darkMode]="darkMode"
       [activeBoard]="activeBoard()"
       (columnAdd)="editBoard()"
@@ -39,5 +42,9 @@
       (taskDeleteModal)="deleteTask($event)"
       (taskUpdateModal)="editTask($event)"
     ></app-project-board>
+    <app-calendar-view
+      *ngIf="viewMode === 'calendar'"
+      [activeBoard]="activeBoard()"
+    ></app-calendar-view>
   </main>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,6 +7,7 @@ import { DeleteModalComponent } from './components/modals/delete-modal/delete-mo
 import { TaskModalComponent } from './components/modals/task-modal/task-modal.component';
 import { NavbarComponent } from './components/navbar/navbar.component';
 import { ProjectBoardComponent } from './components/project-board/project-board.component';
+import { CalendarViewComponent } from './components/calendar-view/calendar-view.component';
 import { SidebarToggleComponent } from './components/sidebar-toggle/sidebar-toggle.component';
 import { SidebarComponent } from './components/sidebar/sidebar.component';
 import { ThemeTogglerComponent } from './components/sidebar/theme-toggler/theme-toggler.component';
@@ -24,6 +25,7 @@ import { BoardDataService } from './services/board-data/board-data.service';
     ThemeTogglerComponent,
     NavbarComponent,
     ProjectBoardComponent,
+    CalendarViewComponent,
     SidebarToggleComponent,
     BoardModalComponent,
     DeleteModalComponent,
@@ -34,6 +36,8 @@ import { BoardDataService } from './services/board-data/board-data.service';
 })
 export class AppComponent implements OnInit {
   darkMode = false;
+
+  viewMode: 'kanban' | 'calendar' = 'kanban';
 
   isSidebarOpen = true;
 
@@ -66,6 +70,10 @@ export class AppComponent implements OnInit {
 
   closeSidebar() {
     this.isSidebarOpen = false;
+  }
+
+  toggleView() {
+    this.viewMode = this.viewMode === 'kanban' ? 'calendar' : 'kanban';
   }
 
   addBoard(): void {

--- a/src/app/components/calendar-view/calendar-view.component.html
+++ b/src/app/components/calendar-view/calendar-view.component.html
@@ -1,0 +1,16 @@
+<div class="calendar-container p-4">
+  <div class="mb-2 grid grid-cols-7 font-bold">
+    <div *ngFor="let day of daysOfWeek" class="text-center">{{ day }}</div>
+  </div>
+  <div class="calendar-weeks flex flex-col gap-2">
+    <div *ngFor="let week of weeks" class="grid grid-cols-7 gap-px">
+      <div
+        *ngFor="let day of week"
+        class="h-24 overflow-auto border p-1 align-top text-xs"
+      >
+        <div class="font-semibold">{{ day.date.getDate() }}</div>
+        <div *ngFor="let task of day.tasks">{{ task.titulo }}</div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/components/calendar-view/calendar-view.component.html
+++ b/src/app/components/calendar-view/calendar-view.component.html
@@ -1,4 +1,9 @@
 <div class="calendar-container p-4">
+  <div class="mb-2 flex items-center justify-between">
+    <button (click)="prevMonth()" class="btn btn-xs">&#60;</button>
+    <span class="font-bold">{{ monthLabel }}</span>
+    <button (click)="nextMonth()" class="btn btn-xs">&#62;</button>
+  </div>
   <div class="mb-2 grid grid-cols-7 font-bold">
     <div *ngFor="let day of daysOfWeek" class="text-center">{{ day }}</div>
   </div>
@@ -9,7 +14,12 @@
         class="h-24 overflow-auto border p-1 align-top text-xs"
       >
         <div class="font-semibold">{{ day.date.getDate() }}</div>
-        <div *ngFor="let task of day.tasks">{{ task.titulo }}</div>
+        <div *ngFor="let task of day.tasks">
+          {{ task.titulo }}
+          <span class="block text-[10px]">
+            {{ task.startDate || '?' }} - {{ task.endDate || '?' }}
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/components/calendar-view/calendar-view.component.scss
+++ b/src/app/components/calendar-view/calendar-view.component.scss
@@ -1,0 +1,3 @@
+.calendar-container {
+  @apply w-full rounded-lg bg-grey-light dark:bg-grey-dark;
+}

--- a/src/app/components/calendar-view/calendar-view.component.spec.ts
+++ b/src/app/components/calendar-view/calendar-view.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CalendarViewComponent } from './calendar-view.component';
+
+describe('CalendarViewComponent', () => {
+  let component: CalendarViewComponent;
+  let fixture: ComponentFixture<CalendarViewComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CalendarViewComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CalendarViewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/calendar-view/calendar-view.component.ts
+++ b/src/app/components/calendar-view/calendar-view.component.ts
@@ -21,14 +21,49 @@ export class CalendarViewComponent implements OnInit {
   weeks: Day[][] = [];
   daysOfWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
+  currentMonth = new Date();
+
   ngOnInit(): void {
     this.generateCalendar();
   }
 
+  prevMonth() {
+    this.currentMonth = new Date(
+      this.currentMonth.getFullYear(),
+      this.currentMonth.getMonth() - 1,
+      1,
+    );
+    this.generateCalendar();
+  }
+
+  nextMonth() {
+    this.currentMonth = new Date(
+      this.currentMonth.getFullYear(),
+      this.currentMonth.getMonth() + 1,
+      1,
+    );
+    this.generateCalendar();
+  }
+
+  get monthLabel(): string {
+    return this.currentMonth.toLocaleString('default', {
+      month: 'long',
+      year: 'numeric',
+    });
+  }
+
   private generateCalendar() {
-    const today = new Date();
-    const firstDay = new Date(today.getFullYear(), today.getMonth(), 1);
-    const lastDay = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+    this.weeks = [];
+    const firstDay = new Date(
+      this.currentMonth.getFullYear(),
+      this.currentMonth.getMonth(),
+      1,
+    );
+    const lastDay = new Date(
+      this.currentMonth.getFullYear(),
+      this.currentMonth.getMonth() + 1,
+      0,
+    );
 
     let current = new Date(firstDay);
     current.setDate(current.getDate() - current.getDay());
@@ -55,7 +90,12 @@ export class CalendarViewComponent implements OnInit {
     const tasks: Task[] = [];
     this.activeBoard.columns.forEach((column) => {
       column.tasks.forEach((task) => {
-        if (task.dueDate === dateStr) {
+        const start = task.startDate ?? task.endDate ?? task.dueDate;
+        const end = task.endDate ?? task.dueDate ?? task.startDate;
+        if (!start || !end) {
+          return;
+        }
+        if (start <= dateStr && dateStr <= end) {
           tasks.push(task);
         }
       });

--- a/src/app/components/calendar-view/calendar-view.component.ts
+++ b/src/app/components/calendar-view/calendar-view.component.ts
@@ -1,0 +1,65 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input, OnInit } from '@angular/core';
+import { Board } from '../../models/board.model';
+import { Task } from '../../models/task.model';
+
+interface Day {
+  date: Date;
+  tasks: Task[];
+}
+
+@Component({
+  selector: 'app-calendar-view',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './calendar-view.component.html',
+  styleUrl: './calendar-view.component.scss',
+})
+export class CalendarViewComponent implements OnInit {
+  @Input() activeBoard: Board | null = null;
+
+  weeks: Day[][] = [];
+  daysOfWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+  ngOnInit(): void {
+    this.generateCalendar();
+  }
+
+  private generateCalendar() {
+    const today = new Date();
+    const firstDay = new Date(today.getFullYear(), today.getMonth(), 1);
+    const lastDay = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+
+    let current = new Date(firstDay);
+    current.setDate(current.getDate() - current.getDay());
+
+    while (current <= lastDay || current.getDay() !== 0) {
+      const week: Day[] = [];
+      for (let i = 0; i < 7; i++) {
+        const date = new Date(current);
+        week.push({ date, tasks: this.tasksForDate(date) });
+        current.setDate(current.getDate() + 1);
+      }
+      this.weeks.push(week);
+      if (current > lastDay && current.getDay() === 0) {
+        break;
+      }
+    }
+  }
+
+  private tasksForDate(date: Date): Task[] {
+    if (!this.activeBoard) {
+      return [];
+    }
+    const dateStr = date.toISOString().slice(0, 10);
+    const tasks: Task[] = [];
+    this.activeBoard.columns.forEach((column) => {
+      column.tasks.forEach((task) => {
+        if (task.dueDate === dateStr) {
+          tasks.push(task);
+        }
+      });
+    });
+    return tasks;
+  }
+}

--- a/src/app/components/modals/task-modal/task-modal.component.html
+++ b/src/app/components/modals/task-modal/task-modal.component.html
@@ -68,6 +68,24 @@
     >
     </textarea>
   </div>
+  <div class="flex flex-col">
+    <h5
+      [ngClass]="{
+        'text-white': data.darkMode,
+        'text-grey-medium': !data.darkMode
+      }"
+      class="mb-0.8 text-sm font-bold leading-sm"
+    >
+      Due Date
+    </h5>
+    <input
+      id="dueDate"
+      type="date"
+      formControlName="dueDate"
+      [ngClass]="{ 'text-white': data.darkMode, 'text-black': !data.darkMode }"
+      class="main-control h-16"
+    />
+  </div>
   <div>
     <h5
       [ngClass]="{
@@ -148,7 +166,7 @@
       Current Status
     </h5>
     <select
-      class="bg-gray-50 border-gray-300 text-gray-900 block w-full rounded-lg border px-2 py-4 text-sm"
+      class="block w-full rounded-lg border border-gray-300 bg-gray-50 px-2 py-4 text-sm text-gray-900"
       [ngClass]="{
         'bg-grey-vdark text-white': data.darkMode,
         'bg-white': !data.darkMode

--- a/src/app/components/modals/task-modal/task-modal.component.html
+++ b/src/app/components/modals/task-modal/task-modal.component.html
@@ -76,12 +76,30 @@
       }"
       class="mb-0.8 text-sm font-bold leading-sm"
     >
-      Due Date
+      Start Date
     </h5>
     <input
-      id="dueDate"
+      id="startDate"
       type="date"
-      formControlName="dueDate"
+      formControlName="startDate"
+      [ngClass]="{ 'text-white': data.darkMode, 'text-black': !data.darkMode }"
+      class="main-control h-16"
+    />
+  </div>
+  <div class="flex flex-col">
+    <h5
+      [ngClass]="{
+        'text-white': data.darkMode,
+        'text-grey-medium': !data.darkMode
+      }"
+      class="mb-0.8 text-sm font-bold leading-sm"
+    >
+      End Date
+    </h5>
+    <input
+      id="endDate"
+      type="date"
+      formControlName="endDate"
       [ngClass]="{ 'text-white': data.darkMode, 'text-black': !data.darkMode }"
       class="main-control h-16"
     />

--- a/src/app/components/modals/task-modal/task-modal.component.ts
+++ b/src/app/components/modals/task-modal/task-modal.component.ts
@@ -54,6 +54,7 @@ export class TaskModalComponent implements OnInit {
           validators: [Validators.required],
         },
       ),
+      dueDate: this.fb.control(this.data.task?.dueDate || ''),
       subtasks: this.fb.array([
         this.fb.nonNullable.group({
           isCompleted: false,

--- a/src/app/components/modals/task-modal/task-modal.component.ts
+++ b/src/app/components/modals/task-modal/task-modal.component.ts
@@ -54,7 +54,10 @@ export class TaskModalComponent implements OnInit {
           validators: [Validators.required],
         },
       ),
-      dueDate: this.fb.control(this.data.task?.dueDate || ''),
+      startDate: this.fb.control(this.data.task?.startDate || ''),
+      endDate: this.fb.control(
+        this.data.task?.endDate || this.data.task?.dueDate || ''
+      ),
       subtasks: this.fb.array([
         this.fb.nonNullable.group({
           isCompleted: false,

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -102,6 +102,12 @@
       Edit Board
     </button>
     <button
+      (click)="toggleView()"
+      class="text-left text-ms font-medium leading-ms text-grey-medium"
+    >
+      {{ viewMode === "kanban" ? "Calendar View" : "Kanban View" }}
+    </button>
+    <button
       (click)="deleteBoard()"
       class="text-left text-ms font-medium leading-ms text-red"
     >

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -15,11 +15,13 @@ export class NavbarComponent {
   @Input() activeBoard!: Board | null;
   @Input() boards!: Board[];
   @Input() darkMode!: boolean;
+  @Input() viewMode: 'kanban' | 'calendar' = 'kanban';
   @Output() boardSelect = new EventEmitter<number>();
   @Output() boardAdd = new EventEmitter<void>();
   @Output() boardEdit = new EventEmitter<void>();
   @Output() boardDelete = new EventEmitter<void>();
   @Output() taskAdd = new EventEmitter<void>();
+  @Output() viewChange = new EventEmitter<void>();
 
   sidebarShown = false;
 
@@ -41,6 +43,10 @@ export class NavbarComponent {
 
   addTask(): void {
     this.taskAdd.emit();
+  }
+
+  toggleView(): void {
+    this.viewChange.emit();
   }
 
   open(): void {

--- a/src/app/models/task.model.ts
+++ b/src/app/models/task.model.ts
@@ -17,4 +17,5 @@ export interface Task {
   status: string;
   subtasks: SubTask[];
   estado: EstadoActividad;
+  dueDate?: string;
 }

--- a/src/app/models/task.model.ts
+++ b/src/app/models/task.model.ts
@@ -17,5 +17,12 @@ export interface Task {
   status: string;
   subtasks: SubTask[];
   estado: EstadoActividad;
+  /** Fecha de inicio de la tarea */
+  startDate?: string;
+
+  /** Fecha de finalización estimada */
+  endDate?: string;
+
+  /** @deprecated Reemplazado por endDate */
   dueDate?: string;
 }

--- a/src/assets/data.json
+++ b/src/assets/data.json
@@ -11,7 +11,8 @@
               "description": "",
               "status": "Todo",
               "prioridad": "Alta",
-              "dueDate": "2024-06-10",
+              "startDate": "2024-06-05",
+              "endDate": "2024-06-10",
               "subtasks": [
                 {
                   "title": "Sign up page",
@@ -32,7 +33,8 @@
               "description": "",
               "status": "Todo",
               "prioridad": "Media",
-              "dueDate": "2024-06-12",
+              "startDate": "2024-06-07",
+              "endDate": "2024-06-12",
               "subtasks": [
                 {
                   "title": "Search page",
@@ -45,7 +47,8 @@
               "description": "",
               "status": "Todo",
               "prioridad": "Media",
-              "dueDate": "2024-06-15",
+              "startDate": "2024-06-10",
+              "endDate": "2024-06-15",
               "subtasks": [
                 {
                   "title": "Account page",
@@ -62,7 +65,8 @@
               "description": "Once we feel version one is ready, we need to rigorously test it both internally and externally to identify any major gaps.",
               "status": "Todo",
               "prioridad": "Baja",
-              "dueDate": "2024-06-20",
+              "startDate": "2024-06-15",
+              "endDate": "2024-06-20",
               "subtasks": [
                 {
                   "title": "Internal testing",
@@ -84,7 +88,8 @@
               "description": "",
               "status": "Doing",
               "prioridad": "Alta",
-              "dueDate": "2024-06-10",
+              "startDate": "2024-06-05",
+              "endDate": "2024-06-10",
               "subtasks": [
                 {
                   "title": "Settings - Account page",
@@ -105,7 +110,8 @@
               "description": "",
               "status": "Doing",
               "prioridad": "Alta",
-              "dueDate": "2024-06-12",
+              "startDate": "2024-06-07",
+              "endDate": "2024-06-12",
               "subtasks": [
                 {
                   "title": "Upgrade plan",
@@ -126,7 +132,8 @@
               "description": "",
               "status": "Doing",
               "prioridad": "Alta",
-              "dueDate": "2024-06-15",
+              "startDate": "2024-06-10",
+              "endDate": "2024-06-15",
               "subtasks": [
                 {
                   "title": "Sign up page",
@@ -147,7 +154,8 @@
               "description": "",
               "status": "Doing",
               "prioridad": "Media",
-              "dueDate": "2024-06-18",
+              "startDate": "2024-06-13",
+              "endDate": "2024-06-18",
               "subtasks": [
                 {
                   "title": "Add search endpoint",
@@ -164,7 +172,8 @@
               "description": "",
               "status": "Doing",
               "prioridad": "Media",
-              "dueDate": "2024-06-21",
+              "startDate": "2024-06-16",
+              "endDate": "2024-06-21",
               "subtasks": [
                 {
                   "title": "Define user model",

--- a/src/assets/data.json
+++ b/src/assets/data.json
@@ -11,6 +11,7 @@
               "description": "",
               "status": "Todo",
               "prioridad": "Alta",
+              "dueDate": "2024-06-10",
               "subtasks": [
                 {
                   "title": "Sign up page",
@@ -31,6 +32,7 @@
               "description": "",
               "status": "Todo",
               "prioridad": "Media",
+              "dueDate": "2024-06-12",
               "subtasks": [
                 {
                   "title": "Search page",
@@ -43,6 +45,7 @@
               "description": "",
               "status": "Todo",
               "prioridad": "Media",
+              "dueDate": "2024-06-15",
               "subtasks": [
                 {
                   "title": "Account page",
@@ -59,6 +62,7 @@
               "description": "Once we feel version one is ready, we need to rigorously test it both internally and externally to identify any major gaps.",
               "status": "Todo",
               "prioridad": "Baja",
+              "dueDate": "2024-06-20",
               "subtasks": [
                 {
                   "title": "Internal testing",
@@ -80,6 +84,7 @@
               "description": "",
               "status": "Doing",
               "prioridad": "Alta",
+              "dueDate": "2024-06-10",
               "subtasks": [
                 {
                   "title": "Settings - Account page",
@@ -100,6 +105,7 @@
               "description": "",
               "status": "Doing",
               "prioridad": "Alta",
+              "dueDate": "2024-06-12",
               "subtasks": [
                 {
                   "title": "Upgrade plan",
@@ -120,6 +126,7 @@
               "description": "",
               "status": "Doing",
               "prioridad": "Alta",
+              "dueDate": "2024-06-15",
               "subtasks": [
                 {
                   "title": "Sign up page",
@@ -140,6 +147,7 @@
               "description": "",
               "status": "Doing",
               "prioridad": "Media",
+              "dueDate": "2024-06-18",
               "subtasks": [
                 {
                   "title": "Add search endpoint",
@@ -156,6 +164,7 @@
               "description": "",
               "status": "Doing",
               "prioridad": "Media",
+              "dueDate": "2024-06-21",
               "subtasks": [
                 {
                   "title": "Define user model",


### PR DESCRIPTION
## Summary
- support due dates for tasks
- handle due dates in the task modal
- provide a calendar view component
- allow switching between Kanban and Calendar modes
- show new view option in navbar menu
- populate sample tasks with due dates

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6841cf84733883299f2fdb4763a92bee